### PR TITLE
Implement recipe engine and suggestion API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ shared libraries, individual services, infrastructure code and client apps.
 See `libs/` for shared code, `services/` for back-end micro services and
 `apps/` for front-end packages. Infrastructure configuration resides under
 `infra/`.
+
+See [docs/GETTING_STARTED.md](docs/GETTING_STARTED.md) for instructions on running the example recipe service.

--- a/docs/GETTING_STARTED.md
+++ b/docs/GETTING_STARTED.md
@@ -1,0 +1,12 @@
+# Getting Started
+
+This project uses a workspace layout with libraries in `libs/` and services in `services/`.
+
+To try the sample recipe suggestion service:
+
+```bash
+pnpm install
+pnpm --filter @recipe-concierge/recipe-service start
+```
+
+Then POST a JSON body like `{ "items": ["tomato", "basil"], "n": 2 }` to `http://localhost:3000/suggestions`.

--- a/libs/recipe-engine/README.md
+++ b/libs/recipe-engine/README.md
@@ -1,0 +1,6 @@
+# Recipe Engine
+
+Simple rule-based recipe suggestion engine.
+
+`suggestRecipes(items, recipes, n)` returns the top `n` recipes
+whose ingredients best match the supplied CSA items.

--- a/libs/recipe-engine/index.ts
+++ b/libs/recipe-engine/index.ts
@@ -1,0 +1,23 @@
+export interface RecipeCandidate {
+  id: string;
+  title: string;
+  ingredients: string[];
+}
+
+export function suggestRecipes(
+  items: string[],
+  recipes: RecipeCandidate[],
+  n: number = 3
+): RecipeCandidate[] {
+  const scores = recipes.map((r) => {
+    const score = r.ingredients.reduce(
+      (sum, ing) => sum + (items.includes(ing) ? 1 : 0),
+      0
+    );
+    return { recipe: r, score };
+  });
+  return scores
+    .sort((a, b) => b.score - a.score)
+    .slice(0, n)
+    .map((s) => s.recipe);
+}

--- a/libs/recipe-engine/package.json
+++ b/libs/recipe-engine/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@recipe-concierge/recipe-engine",
+  "version": "0.1.0",
+  "main": "index.ts"
+}

--- a/services/recipe-service/package.json
+++ b/services/recipe-service/package.json
@@ -3,6 +3,9 @@
   "version": "0.1.0",
   "main": "src/index.ts",
   "scripts": {
-    "start": "node dist/index.js"
+    "start": "ts-node src/index.ts"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
   }
 }

--- a/services/recipe-service/src/index.ts
+++ b/services/recipe-service/src/index.ts
@@ -1,3 +1,52 @@
-export function start() {
-  console.log('Starting $svc');
+import express from 'express';
+import { RecipeRepo } from './infra/RecipeRepo';
+import { RecipeController } from './controllers/RecipeController';
+import { suggestRecipes, RecipeCandidate } from '@recipe-concierge/recipe-engine';
+import { RecipeInput } from './domain/Recipe';
+
+const repo = new RecipeRepo();
+const controller = new RecipeController(repo);
+
+const sampleRecipes: RecipeInput[] = [
+  {
+    id: '1',
+    title: 'Tomato Pasta',
+    ingredients: ['tomato', 'pasta', 'basil'],
+    prepMinutes: 10,
+    cookMinutes: 20,
+    skillLevel: 1,
+  },
+  {
+    id: '2',
+    title: 'Veggie Stir Fry',
+    ingredients: ['broccoli', 'carrot', 'soy sauce'],
+    prepMinutes: 15,
+    cookMinutes: 10,
+    skillLevel: 1,
+  },
+];
+
+for (const data of sampleRecipes) {
+  controller.import(data);
+}
+
+export function start(port: number = 3000) {
+  const app = express();
+  app.use(express.json());
+
+  app.post('/suggestions', (req, res) => {
+    const items: string[] = req.body.items || [];
+    const n: number = req.body.n || 3;
+    const candidates: RecipeCandidate[] = repo.all().map((r) => r.info);
+    const suggestions = suggestRecipes(items, candidates, n);
+    res.json({ recipes: suggestions });
+  });
+
+  app.listen(port, () => {
+    console.log(`recipe-service listening on ${port}`);
+  });
+}
+
+if (require.main === module) {
+  start();
 }


### PR DESCRIPTION
## Summary
- add `recipe-engine` library with a simple matcher
- expose `POST /suggestions` in recipe-service using express
- document how to run the example

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6882f7335f84832dbc928469516728e0