### PR TITLE
Add recipe generation endpoint

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "@recipe-concierge/web",
+  "version": "0.1.0"
+}

--- a/apps/web/pages/csa-recipes.tsx
+++ b/apps/web/pages/csa-recipes.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+const options = ['carrot','tomato','onion','spinach','broccoli']
+
+export default function CsaRecipes() {
+  const [items, setItems] = useState<string[]>([])
+  const [recipes, setRecipes] = useState<any[]>([])
+
+  const toggle = (i: string) => {
+    setItems(prev => prev.includes(i) ? prev.filter(p => p !== i) : [...prev, i])
+  }
+
+  const generate = async () => {
+    const r = await fetch('/recipes', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ items })
+    })
+    setRecipes(await r.json())
+  }
+
+  return (
+    <div>
+      <h1>CSA Recipes</h1>
+      <div>
+        {options.map(o => (
+          <label key={o} style={{ marginRight: '1em' }}>
+            <input type="checkbox" checked={items.includes(o)} onChange={() => toggle(o)} /> {o}
+          </label>
+        ))}
+      </div>
+      <button onClick={generate}>Generate recipes</button>
+      <ul>
+        {recipes.map(r => <li key={r.id}>{r.title}</li>)}
+      </ul>
+    </div>
+  )
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     environment:
       DATABASE_URL: postgres://postgres:secret@db:5432/recipes
       PORT: 3000
+      OPENAI_API_KEY: ${OPENAI_API_KEY}
+      SPOONACULAR_KEY: ${SPOONACULAR_KEY}
     depends_on:
       db:
         condition: service_healthy

--- a/libs/food-normaliser/index.ts
+++ b/libs/food-normaliser/index.ts
@@ -1,0 +1,10 @@
+const synonyms: Record<string, string> = {
+  cilantro: 'coriander',
+  courgette: 'zucchini',
+  scallion: 'spring onion'
+};
+
+export function normalize(name: string): string {
+  const key = name.trim().toLowerCase();
+  return synonyms[key] || key;
+}

--- a/libs/food-normaliser/package.json
+++ b/libs/food-normaliser/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@recipe-concierge/food-normaliser",
+  "version": "0.1.0",
+  "main": "index.ts"
+}

--- a/libs/recipe-types/index.ts
+++ b/libs/recipe-types/index.ts
@@ -1,0 +1,16 @@
+export interface Recipe {
+  id: string;
+  title: string;
+  servings: number;
+  readyInMinutes: number;
+  ingredients: Array<{ name: string; quantity: string }>;
+  instructions: string[];
+  missingItems: string[];
+  nutrition: {
+    calories: number;
+    protein_g: number;
+    carbs_g: number;
+    fat_g: number;
+  };
+  source: 'spoonacular' | 'openai';
+}

--- a/libs/recipe-types/package.json
+++ b/libs/recipe-types/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@recipe-concierge/recipe-types",
+  "version": "0.1.0",
+  "main": "index.ts"
+}

--- a/services/recipe-service/src/index.ts
+++ b/services/recipe-service/src/index.ts
@@ -6,6 +6,7 @@ import { apiKey } from './middleware/apiKey'
 import expressPino from 'express-pino-logger'
 import { logger } from './logger'
 import { collectDefaultMetrics, Registry } from 'prom-client'
+import { generateRecipes } from './recipeGen'
 
 const repo = new RecipeRepo(db)
 const reg = new Registry()
@@ -29,6 +30,18 @@ export function start(port: number = Number(process.env.PORT) || 3000) {
     const candidates: RecipeCandidate[] = recipes.map(r => r.info)
     const suggestions = suggestRecipes(items, candidates, n)
     res.json(suggestions)
+  })
+
+  app.post('/recipes', async (req, res) => {
+    try {
+      const items: string[] = req.body.items || []
+      const servings: number | undefined = req.body.servings
+      const recipes = await generateRecipes(items, { servings })
+      res.json(recipes)
+    } catch (err) {
+      logger.error({ err }, 'generation failed')
+      res.status(500).json({ error: 'generation_failed' })
+    }
   })
 
   app.listen(port, () => {

--- a/services/recipe-service/src/recipeGen.ts
+++ b/services/recipe-service/src/recipeGen.ts
@@ -1,0 +1,59 @@
+import { normalize } from '@recipe-concierge/food-normaliser'
+import { Recipe } from '@recipe-concierge/recipe-types'
+import { randomUUID } from 'crypto'
+
+async function fetchSpoonacular(items: string[]): Promise<Recipe[]> {
+  const key = process.env.SPOONACULAR_KEY
+  if (!key) return []
+  const url = `https://api.spoonacular.com/recipes/findByIngredients?ingredients=${encodeURIComponent(items.join(','))}&number=5&apiKey=${key}`
+  const res = await fetch(url)
+  if (!res.ok) return []
+  const data = await res.json()
+  return (data as any[]).map((r) => ({
+    id: randomUUID(),
+    title: r.title,
+    servings: r.servings || 2,
+    readyInMinutes: r.readyInMinutes || 30,
+    ingredients: (r.usedIngredients || []).map((i: any) => ({ name: i.name, quantity: `${i.amount} ${i.unit}` })),
+    instructions: [],
+    missingItems: (r.missedIngredients || []).map((m: any) => m.name),
+    nutrition: { calories: 0, protein_g: 0, carbs_g: 0, fat_g: 0 },
+    source: 'spoonacular'
+  }))
+}
+
+async function fetchOpenAI(items: string[], servings?: number): Promise<Recipe[]> {
+  const key = process.env.OPENAI_API_KEY
+  if (!key) return []
+  const prompt = `Create one recipe using ${items.join(', ')}. Respond with JSON.`
+  const body = {
+    model: 'gpt-4o',
+    messages: [{ role: 'user', content: prompt }],
+    temperature: 0.7
+  }
+  const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${key}`
+    },
+    body: JSON.stringify(body)
+  })
+  if (!res.ok) return []
+  const json = await res.json()
+  const text = json.choices?.[0]?.message?.content
+  if (!text) return []
+  try {
+    const r = JSON.parse(text)
+    return [Object.assign(r, { id: randomUUID(), source: 'openai' })]
+  } catch {
+    return []
+  }
+}
+
+export async function generateRecipes(items: string[], opts?: { servings?: number }): Promise<Recipe[]> {
+  const normalized = items.map(normalize)
+  const spoon = await fetchSpoonacular(normalized)
+  if (spoon.length) return spoon
+  return await fetchOpenAI(normalized, opts?.servings)
+}


### PR DESCRIPTION
## Summary
- define shared `Recipe` interface in new `libs/recipe-types`
- add tiny synonym normaliser library
- implement `generateRecipes` helper with Spoonacular and OpenAI calls
- expose POST `/recipes` in `recipe-service`
- wire new env vars in docker compose
- stub web page for CSA recipe generation

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6883057f2560832d811d82020f57a343